### PR TITLE
ci: add GitHub Actions workflow running gradle check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+      - uses: gradle/actions/setup-gradle@v4
+      - name: Write local.properties
+        run: echo "google_maps_key=${{ secrets.GOOGLE_MAPS_KEY }}" > local.properties
+      - run: ./gradlew check --stacktrace
+      - name: Upload reports
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: reports
+          path: '**/build/reports/**'


### PR DESCRIPTION
Adds a CI workflow that runs the project gate on PRs and pushes to master.

- Triggers on pull_request and push targeting master.
- Temurin 21, Gradle caching via gradle/actions/setup-gradle.
- Writes local.properties from the GOOGLE_MAPS_KEY secret. Gradle reads google_maps_key at configuration time, so it must exist before check runs.
- Runs ./gradlew check. Uploads build reports on failure.

Requires a repo secret named GOOGLE_MAPS_KEY. Any non-empty value works for check since it builds and tests debug without hitting the network.

./gradlew check passed.