### PR TITLE
docs: point workflow references at main

### DIFF
--- a/.claude/commands/create-pr.md
+++ b/.claude/commands/create-pr.md
@@ -24,10 +24,10 @@ this change.
      ```
 
    - Push the branch.
-   - Open a draft PR against master:
+   - Open a draft PR against main:
 
      ```bash
-     gh pr create --draft --base master
+     gh pr create --draft --base main
      ```
 
      Keep the title and body terse and human-readable. Same style rules. End the body

--- a/.claude/commands/create-pr.md
+++ b/.claude/commands/create-pr.md
@@ -1,5 +1,5 @@
 ---
-description: Verify with ./gradlew check, then commit and open a draft PR
+description: Verify with ./gradlew check, then commit and open a PR
 ---
 
 Finish the current change and open it for review. Run this from inside the worktree for
@@ -24,10 +24,10 @@ this change.
      ```
 
    - Push the branch.
-   - Open a draft PR against main:
+   - Open a PR against main:
 
      ```bash
-     gh pr create --draft --base main
+     gh pr create --base main
      ```
 
      Keep the title and body terse and human-readable. Same style rules. End the body

--- a/.claude/commands/start-implement.md
+++ b/.claude/commands/start-implement.md
@@ -1,5 +1,5 @@
 ---
-description: Start an isolated change in a fresh git worktree off master
+description: Start an isolated change in a fresh git worktree off main
 argument-hint: <type> <slug>
 ---
 
@@ -8,10 +8,10 @@ Start a new isolated change. Type is `$1`. Slug is `$2`.
 Steps:
 
 1. Check `$1` is one of feat, fix, refactor, chore, build, docs. If not, stop and ask.
-2. From the main checkout root, create a worktree and branch off master:
+2. From the main checkout root, create a worktree and branch off main:
 
    ```bash
-   git worktree add -b $1/$2 ../GanzhornfestCompose-$2 master
+   git worktree add -b $1/$2 ../GanzhornfestCompose-$2 main
    ```
 
 3. Bootstrap the worktree so Gradle can configure and build.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,8 @@ setup. This file only covers how to work here.
 ## Workflow
 
 Every change runs in its own git worktree off `main`, so parallel agents never edit
-each other's files.
+each other's files. Any request to fix, implement, or change something goes through this
+flow. Run `/start-implement` before making the change and `/create-pr` after.
 
 1. `/start-implement <type> <slug>` creates the worktree and branch `<type>/<slug>`, then
    bootstraps it (copies `local.properties`, writes a stub `keystore.properties`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,14 +7,14 @@ setup. This file only covers how to work here.
 
 ## Workflow
 
-Every change runs in its own git worktree off `master`, so parallel agents never edit
+Every change runs in its own git worktree off `main`, so parallel agents never edit
 each other's files.
 
 1. `/start-implement <type> <slug>` creates the worktree and branch `<type>/<slug>`, then
    bootstraps it (copies `local.properties`, writes a stub `keystore.properties`).
 2. Make the change inside that worktree.
 3. `/create-pr` runs `./gradlew check`. Only if it passes does it commit, push, and open
-   a draft PR against `master`.
+   a draft PR against `main`.
 
 `type` is one of feat, fix, refactor, chore, build, docs.
 


### PR DESCRIPTION
The default branch was renamed from master to main. This updates CLAUDE.md and the start-implement and create-pr commands to reference main so the worktree workflow keeps working.

./gradlew check passed.